### PR TITLE
Provide a dispatcher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,9 @@ version = "0.1.0"
 authors = ["huntc <huntchr@gmail.com>"]
 edition = "2018"
 
+[dependencies]
+crossbeam-channel = "0.5"
+
 [dev-dependencies]
 async-std = "1.9.0"
+executors = "0.8.0"


### PR DESCRIPTION
Provides a dispatcher mechanism, which is simply a means by which an actor context is able to submit tasks to an executor.

TODO:

* [x] Finish up the dispatcher by selecting a receiver and sending the action closure to the work pool
* [x] Implement the unimplemented code sections