### PR TITLE
Logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,9 @@ edition = "2018"
 
 [dependencies]
 crossbeam-channel = "0.5"
+log = "0.4"
 
 [dev-dependencies]
 async-std = "1.9.0"
+env_logger = "0.8.3"
 executors = "0.8.0"


### PR DESCRIPTION
Plus addresses all but one TODO (which is to implement ask - will be a separate PR).

Quite cool to have the logging as I can see what the executors are doing too:

```
% RUST_LOG=debug cargo test -- --nocapture
    Finished test [unoptimized + debuginfo] target(s) in 0.05s
     Running target/debug/deps/stage-7622cfa5a48da80e

running 1 test
[2021-03-27T00:22:10Z DEBUG executors::crossbeam_workstealing_pool] Worker 0 starting
[2021-03-27T00:22:10Z DEBUG executors::crossbeam_workstealing_pool] Worker 1 starting
[2021-03-27T00:22:10Z DEBUG executors::crossbeam_workstealing_pool] Scheduling on global pool.
[2021-03-27T00:22:10Z DEBUG executors::crossbeam_workstealing_pool] Worker 3 starting
[2021-03-27T00:22:10Z DEBUG executors::crossbeam_workstealing_pool] Worker 2 starting
[2021-03-27T00:22:10Z DEBUG executors::crossbeam_workstealing_pool] Registered stealer for #3
[2021-03-27T00:22:10Z DEBUG executors::crossbeam_workstealing_pool] Registered stealer for #1
[2021-03-27T00:22:10Z DEBUG executors::crossbeam_workstealing_pool] Scheduling on global pool.
Hello World!
Hello Stage!
[2021-03-27T00:22:10Z DEBUG executors::crossbeam_workstealing_pool] Scheduling on global pool.
Greeting 1 for World
[2021-03-27T00:22:10Z DEBUG executors::crossbeam_workstealing_pool] Registered stealer for #0
[2021-03-27T00:22:10Z DEBUG executors::crossbeam_workstealing_pool] Scheduling on global pool.
Greeting 1 for Stage
[2021-03-27T00:22:10Z DEBUG executors::crossbeam_workstealing_pool] Scheduling on global pool.
[2021-03-27T00:22:10Z DEBUG executors::crossbeam_workstealing_pool] Registered stealer for #2
Hello World!
Hello Stage!
[2021-03-27T00:22:10Z DEBUG executors::crossbeam_workstealing_pool] Scheduling on global pool.
Greeting 2 for World
[2021-03-27T00:22:10Z DEBUG executors::crossbeam_workstealing_pool] Scheduling on global pool.
Hello World!
[2021-03-27T00:22:10Z DEBUG executors::crossbeam_workstealing_pool] Scheduling on global pool.
Greeting 2 for Stage
[2021-03-27T00:22:10Z DEBUG executors::crossbeam_workstealing_pool] Scheduling on global pool.
Greeting 3 for World
[2021-03-27T00:22:10Z DEBUG executors::crossbeam_workstealing_pool] Scheduling on global pool.
Hello Stage!
[2021-03-27T00:22:10Z DEBUG executors::crossbeam_workstealing_pool] Scheduling on global pool.
Greeting 3 for Stage
[2021-03-27T00:22:11Z DEBUG executors::crossbeam_workstealing_pool] Shutting down 4 threads
test tests::test_greeting ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out[2021-03-27T00:22:11Z DEBUG executors::crossbeam_workstealing_pool] Dropping worker #0
; finished in 0.50s

[2021-03-27T00:22:11Z DEBUG executors::crossbeam_workstealing_pool] Worker 0 shutting down
   Doc-tests stage

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

% 
```
