### PR TITLE
Introducing benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "benchmarks",
     "core",
     "executors",
     "tokio",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "benchmarks"
+version = "0.1.0"
+authors = ["Titan Class P/L"]
+edition = "2018"
+license = "Apache-2.0"
+description = "Benchmarking for Stage"
+homepage = "https://www.titanclass.com.au/"
+repository = "https://github.com/titanclass/stage"
+readme = "README.md"
+publish = false
+
+[dev-dependencies]
+criterion = {version = "0.3", features = ["async_tokio", "html_reports"]}
+crossbeam-channel = "0.5"
+executors = "0.8.0"
+stage_core = { path = "../core" }
+stage_dispatch_crossbeam_executors = { path = "../executors" }
+stage_dispatch_tokio = { path = "../tokio" }
+tokio = { version = "1", features = ["rt-multi-thread"] }
+
+[[bench]]
+name = "actors"
+harness = false

--- a/benchmarks/benches/actors.rs
+++ b/benchmarks/benches/actors.rs
@@ -1,0 +1,251 @@
+use std::{sync::Arc, thread};
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use crossbeam_channel::{bounded as cb_bounded, unbounded as cb_unbounded, Receiver as CbReceiver};
+use executors::crossbeam_workstealing_pool;
+use stage_core::{Actor, ActorContext, ActorRef, AnyMessage};
+use stage_dispatch_crossbeam_executors::{
+    bounded_mailbox_fn as cbe_bounded_mailbox_fn, unbounded_mailbox_fn as cbe_unbounded_mailbox_fn,
+    WorkStealingPoolDispatcher,
+};
+use stage_dispatch_tokio::{
+    mailbox_fn as tk_mailbox_fn, unbounded_mailbox_fn as tk_unbounded_mailbox_fn, TokioDispatcher,
+    TokioUnboundedDispatcher,
+};
+use tokio::sync::mpsc::{
+    channel as tk_channel, unbounded_channel as tk_unbounded_channel, Receiver as TkReceiver,
+    UnboundedReceiver as TkUnboundedReceiver,
+};
+
+// Fixtures
+
+struct Request {
+    reply_to: ActorRef<Reply>,
+}
+struct Reply {}
+struct MyActor {}
+impl Actor<Request> for MyActor {
+    fn receive(&mut self, _context: &mut ActorContext<Request>, message: &Request) {
+        message.reply_to.tell(Reply {})
+    }
+}
+
+// Benchmarks
+
+fn send_messages_to_other_actors_bounded_cbe(c: &mut Criterion) {
+    let pool = crossbeam_workstealing_pool::small_pool(4);
+    let (command_tx, command_rx) = cb_bounded(1);
+    let dispatcher = Arc::new(WorkStealingPoolDispatcher { pool, command_tx });
+
+    let mailbox_fn = Arc::new(cbe_bounded_mailbox_fn(1));
+
+    let dispatcher_thread_dispatcher = dispatcher.to_owned();
+    let _ = thread::spawn(move || dispatcher_thread_dispatcher.start(command_rx));
+
+    let my_actor = ActorContext::<Request>::new(
+        || Box::new(MyActor {}),
+        dispatcher.to_owned(),
+        mailbox_fn.to_owned(),
+    );
+
+    c.bench_function(
+        "send messages to other actors using Crossbeam and Executors with bounded channels",
+        |b| {
+            b.iter(|| {
+                let mut ask_receiver = my_actor.actor_ref.ask(
+                    &|reply_to| Request {
+                        reply_to: reply_to.to_owned(),
+                    },
+                    mailbox_fn.to_owned(),
+                );
+                let _ = ask_receiver
+                    .receiver_impl
+                    .as_any()
+                    .downcast_ref::<CbReceiver<AnyMessage>>()
+                    .unwrap()
+                    .recv()
+                    .unwrap()
+                    .downcast_ref::<Reply>()
+                    .unwrap();
+            });
+        },
+    );
+}
+
+fn send_messages_to_other_actors_unbounded_cbe(c: &mut Criterion) {
+    let pool = crossbeam_workstealing_pool::small_pool(4);
+    let (command_tx, command_rx) = cb_unbounded();
+    let dispatcher = Arc::new(WorkStealingPoolDispatcher { pool, command_tx });
+
+    let mailbox_fn = Arc::new(cbe_unbounded_mailbox_fn());
+
+    let dispatcher_thread_dispatcher = dispatcher.to_owned();
+    let _ = thread::spawn(move || dispatcher_thread_dispatcher.start(command_rx));
+
+    let my_actor = ActorContext::<Request>::new(
+        || Box::new(MyActor {}),
+        dispatcher.to_owned(),
+        mailbox_fn.to_owned(),
+    );
+
+    c.bench_function(
+        "send messages to other actors using Crossbeam and Executors with unbounded channels",
+        |b| {
+            b.iter(|| {
+                let mut ask_receiver = my_actor.actor_ref.ask(
+                    &|reply_to| Request {
+                        reply_to: reply_to.to_owned(),
+                    },
+                    mailbox_fn.to_owned(),
+                );
+                let _ = ask_receiver
+                    .receiver_impl
+                    .as_any()
+                    .downcast_ref::<CbReceiver<AnyMessage>>()
+                    .unwrap()
+                    .recv()
+                    .unwrap()
+                    .downcast_ref::<Reply>()
+                    .unwrap();
+            });
+        },
+    );
+}
+
+fn send_messages_to_other_actors_bounded_tk(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let (command_tx, command_rx) = tk_channel(1);
+    let dispatcher = Arc::new(TokioDispatcher { command_tx });
+    let mailbox_fn = Arc::new(tk_mailbox_fn(1));
+
+    let my_actor = ActorContext::<Request>::new(
+        || Box::new(MyActor {}),
+        dispatcher.to_owned(),
+        mailbox_fn.to_owned(),
+    );
+
+    let dispatcher_task_dispatcher = dispatcher.to_owned();
+    let _ = rt.spawn(async move { dispatcher_task_dispatcher.start(command_rx).await });
+
+    c.bench_function(
+        "send messages to other actors using Tokio with bounded channels",
+        |b| {
+            b.to_async(&rt).iter(|| async {
+                let mut ask_receiver = my_actor.actor_ref.ask(
+                    &|reply_to| Request {
+                        reply_to: reply_to.to_owned(),
+                    },
+                    mailbox_fn.to_owned(),
+                );
+                let _ = ask_receiver
+                    .receiver_impl
+                    .as_any()
+                    .downcast_mut::<TkReceiver<AnyMessage>>()
+                    .unwrap()
+                    .recv()
+                    .await
+                    .unwrap()
+                    .downcast_ref::<Reply>()
+                    .unwrap();
+            });
+        },
+    );
+}
+
+fn send_messages_to_other_actors_unbounded_tk(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let (command_tx, command_rx) = tk_unbounded_channel();
+    let dispatcher = Arc::new(TokioUnboundedDispatcher { command_tx });
+    let mailbox_fn = Arc::new(tk_unbounded_mailbox_fn());
+
+    let my_actor = ActorContext::<Request>::new(
+        || Box::new(MyActor {}),
+        dispatcher.to_owned(),
+        mailbox_fn.to_owned(),
+    );
+
+    let dispatcher_task_dispatcher = dispatcher.to_owned();
+    let _ = rt.spawn(async move { dispatcher_task_dispatcher.start(command_rx).await });
+
+    c.bench_function(
+        "send messages to other actors using Tokio with unbounded channels",
+        |b| {
+            b.to_async(&rt).iter(|| async {
+                let mut ask_receiver = my_actor.actor_ref.ask(
+                    &|reply_to| Request {
+                        reply_to: reply_to.to_owned(),
+                    },
+                    mailbox_fn.to_owned(),
+                );
+                let _ = ask_receiver
+                    .receiver_impl
+                    .as_any()
+                    .downcast_mut::<TkUnboundedReceiver<AnyMessage>>()
+                    .unwrap()
+                    .recv()
+                    .await
+                    .unwrap()
+                    .downcast_ref::<Reply>()
+                    .unwrap();
+            });
+        },
+    );
+}
+
+fn create_new_actors_unbounded_cbe(c: &mut Criterion) {
+    let pool = crossbeam_workstealing_pool::small_pool(4);
+    let (command_tx, command_rx) = cb_unbounded();
+    let dispatcher = Arc::new(WorkStealingPoolDispatcher { pool, command_tx });
+
+    let mailbox_fn = Arc::new(cbe_unbounded_mailbox_fn());
+
+    let dispatcher_thread_dispatcher = dispatcher.to_owned();
+    let _ = thread::spawn(move || dispatcher_thread_dispatcher.start(command_rx));
+
+    c.bench_function(
+        "create new actors using Crossbeam and Executors with unbounded channels",
+        |b| {
+            b.iter(|| {
+                let _ = ActorContext::<Request>::new(
+                    || Box::new(MyActor {}),
+                    dispatcher.to_owned(),
+                    mailbox_fn.to_owned(),
+                );
+            });
+        },
+    );
+}
+
+fn create_new_actors_unbounded_tk(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let (command_tx, command_rx) = tk_unbounded_channel();
+    let dispatcher = Arc::new(TokioUnboundedDispatcher { command_tx });
+    let mailbox_fn = Arc::new(tk_unbounded_mailbox_fn());
+
+    let dispatcher_task_dispatcher = dispatcher.to_owned();
+    let _ = rt.spawn(async move { dispatcher_task_dispatcher.start(command_rx).await });
+
+    c.bench_function(
+        "create new actors using Tokio with unbounded channels",
+        |b| {
+            b.to_async(&rt).iter(|| async {
+                let _ = ActorContext::<Request>::new(
+                    || Box::new(MyActor {}),
+                    dispatcher.to_owned(),
+                    mailbox_fn.to_owned(),
+                );
+            });
+        },
+    );
+}
+
+criterion_group!(
+    benches,
+    send_messages_to_other_actors_bounded_cbe,
+    send_messages_to_other_actors_unbounded_cbe,
+    send_messages_to_other_actors_bounded_tk,
+    send_messages_to_other_actors_unbounded_tk,
+    create_new_actors_unbounded_cbe,
+    create_new_actors_unbounded_tk,
+);
+criterion_main!(benches);

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,13 +1,13 @@
 #![cfg_attr(not(test), no_std)]
 
-use core::{any::Any, fmt::Debug, marker::PhantomData, time::Duration};
+use core::{any::Any, fmt::Debug, marker::PhantomData};
 
 extern crate alloc;
 use crate::alloc::borrow::ToOwned;
 use crate::alloc::{boxed::Box, sync::Arc};
 
 pub mod channel;
-use channel::{Receiver, RecvTimeoutError, Sender, TrySendError};
+use channel::{Receiver, Sender, TrySendError};
 
 use log::{debug, warn};
 
@@ -165,11 +165,20 @@ impl<M: Send + 'static> ActorRef<M> {
     /// Perform an ask operation on the associated actor
     /// while passing in a function to construct a message
     /// that accepts a reply_to sender
-    pub async fn ask<F, M2>(&self, _f: F, _recv_timeout: Duration) -> Result<M2, RecvTimeoutError>
+    pub fn ask<M2>(
+        &self,
+        request_fn: &dyn Fn(&ActorRef<M2>) -> M,
+        mailbox_fn: Arc<dyn Fn() -> (Sender<AnyMessage>, Receiver<AnyMessage>)>,
+    ) -> Receiver<AnyMessage>
     where
-        F: FnOnce() -> M + 'static,
+        M2: Send + 'static,
     {
-        unimplemented!() // FIXME
+        let (reply_tx, reply_rx) = mailbox_fn();
+        let _ = self.sender.try_send(Box::new(request_fn(&ActorRef {
+            phantom_marker: PhantomData::<M2>,
+            sender: reply_tx,
+        })));
+        reply_rx
     }
 
     /// Best effort send a message to the associated actor
@@ -194,4 +203,183 @@ impl<M> Debug for ActorRef<M> {
 }
 
 #[cfg(test)]
-mod tests {} // FIXME: Need tests at this level!
+mod tests {
+    use channel::{ReceiverImpl, SenderImpl};
+
+    use super::*;
+
+    use std::sync::mpsc::{sync_channel, Receiver as SyncReceiver, SyncSender};
+    use std::sync::mpsc::{RecvError as SyncRecvError, TrySendError as SyncTrySendError};
+
+    // This test provides reasonable coverage across the core APIs. A dispatcher is
+    // set up to process command messages and actor messages synchronously to reason
+    // the tests more easily.
+    #[test]
+    fn test_ask() {
+        // Declare our actor to test - a simply recipient of a request and a reply
+
+        struct Request {
+            reply_to: ActorRef<Reply>,
+            reply_with: u32,
+        }
+        struct Reply {
+            value: u32,
+        }
+        struct MyActor {}
+        impl Actor<Request> for MyActor {
+            fn receive(&mut self, _context: &mut ActorContext<Request>, message: &Request) {
+                message.reply_to.tell(Reply {
+                    value: message.reply_with,
+                })
+            }
+        }
+
+        // Declares a dispatcher to process commands and actor messages synchronously
+
+        struct MyDispatcher {
+            command_tx: SyncSender<AnyMessage>,
+        }
+        impl MyDispatcher {
+            pub fn receive_command(
+                &self,
+                command_rx: &SyncReceiver<AnyMessage>,
+            ) -> Result<Option<SelectWithAction>, SyncRecvError> {
+                match command_rx.recv() {
+                    Ok(message) => Ok(match message.downcast::<DispatcherCommand>() {
+                        Ok(dispatcher_command) => match *dispatcher_command {
+                            DispatcherCommand::SelectWithAction { underlying } => Some(underlying),
+                            DispatcherCommand::Stop => None,
+                        },
+                        Err(e) => {
+                            warn!(
+                                "Error received when expecting a dispatcher command: {:?}",
+                                e
+                            );
+                            None
+                        }
+                    }),
+                    Err(e) => Err(e),
+                }
+            }
+            pub fn receive_messages(&self, selection: &mut SelectWithAction) {
+                let receiver = selection
+                    .receiver
+                    .receiver_impl
+                    .as_any()
+                    .downcast_ref::<SyncReceiver<AnyMessage>>()
+                    .unwrap();
+                while let Ok(m) = receiver.try_recv() {
+                    let active = (selection.action)(m);
+                    if !active {
+                        break;
+                    }
+                }
+            }
+        }
+        impl Dispatcher for MyDispatcher {
+            fn send(&self, command: DispatcherCommand) -> Result<(), TrySendError<AnyMessage>> {
+                self.command_tx
+                    .try_send(Box::new(command))
+                    .map_err(|e| match e {
+                        SyncTrySendError::Disconnected(e) => TrySendError::Disconnected(e),
+                        SyncTrySendError::Full(e) => TrySendError::Full(e),
+                    })
+            }
+        }
+        struct SyncReceiverImpl {
+            receiver: SyncReceiver<AnyMessage>,
+        }
+        impl ReceiverImpl for SyncReceiverImpl {
+            type Item = AnyMessage;
+
+            fn as_any(&mut self) -> &mut (dyn Any + Send) {
+                &mut self.receiver
+            }
+        }
+        struct SyncSenderImpl {
+            sender: SyncSender<AnyMessage>,
+        }
+        impl SenderImpl for SyncSenderImpl {
+            type Item = AnyMessage;
+
+            fn clone(&self) -> Box<dyn SenderImpl<Item = AnyMessage> + Send + Sync> {
+                Box::new(SyncSenderImpl {
+                    sender: self.sender.to_owned(),
+                })
+            }
+
+            fn try_send(&self, msg: AnyMessage) -> Result<(), TrySendError<AnyMessage>> {
+                match self.sender.try_send(msg) {
+                    Ok(_) => Ok(()),
+                    Err(SyncTrySendError::Disconnected(e)) => Err(TrySendError::Disconnected(e)),
+                    Err(SyncTrySendError::Full(e)) => Err(TrySendError::Full(e)),
+                }
+            }
+        }
+        pub fn sync_mailbox_fn(
+            buffer: usize,
+        ) -> Box<dyn Fn() -> (Sender<AnyMessage>, Receiver<AnyMessage>) + Send + Sync> {
+            Box::new(move || {
+                let (mailbox_tx, mailbox_rx) = sync_channel(buffer);
+                (
+                    Sender {
+                        sender_impl: Box::new(SyncSenderImpl {
+                            sender: mailbox_tx.to_owned(),
+                        }),
+                    },
+                    Receiver {
+                        receiver_impl: Box::new(SyncReceiverImpl {
+                            receiver: mailbox_rx,
+                        }),
+                    },
+                )
+            })
+        }
+
+        // Establish the dispatcher and mailbox
+
+        let (command_tx, command_rx) = sync_channel::<AnyMessage>(1);
+        let dispatcher = Arc::new(MyDispatcher { command_tx });
+
+        let mailbox_fn = Arc::new(sync_mailbox_fn(1));
+
+        // Establish our root actor and get a handle to the actor's receiver
+
+        let my_actor = ActorContext::<Request>::new(
+            || Box::new(MyActor {}),
+            dispatcher.to_owned(),
+            mailbox_fn.to_owned(),
+        );
+        let selection = dispatcher.receive_command(&command_rx);
+
+        // Send an ask request to the actor and have the actor process its
+        // messages
+
+        let expected_reply_value = 10;
+
+        let mut ask_receiver = my_actor.actor_ref.ask(
+            &|reply_to| Request {
+                reply_to: reply_to.to_owned(),
+                reply_with: expected_reply_value,
+            },
+            mailbox_fn,
+        );
+        dispatcher.receive_messages(&mut selection.unwrap().unwrap());
+
+        // Test the ask reply
+
+        assert_eq!(
+            ask_receiver
+                .receiver_impl
+                .as_any()
+                .downcast_ref::<SyncReceiver<AnyMessage>>()
+                .unwrap()
+                .recv()
+                .unwrap()
+                .downcast_ref::<Reply>()
+                .unwrap()
+                .value,
+            expected_reply_value
+        )
+    }
+}


### PR DESCRIPTION
A separate sub-project is introduced to benchmarking for Stage and each of its executors w.r.t. to the things that actors are capable of i.e. sending messages to other actors; and creating new actors.

To achieve the benchmark logic, I've implemented the `ask` method on `ActorRef`. I'm not entirely happy with its implementation right now, as it exposes the `Receiver` type to the caller. There's more work to do there; perhaps as a separate PR though. I'm thinking that the `ask` method should be `async` instead, but it would also require another method on the `Receive` type to actually receive. More thinking required.

Prelim benchmarks show Crossbeam/Executors to be significantly faster:

```
send messages to other actors using Crossbeam and Executors with bounded channels                                                                             
                        time:   [3.5891 us 3.6211 us 3.6609 us]

send messages to other actors using Crossbeam and Executors with unbounded channels                                                                             
                        time:   [3.4969 us 3.5105 us 3.5262 us]

send messages to other actors using Tokio with bounded channels                                                                             
                        time:   [10.952 us 11.087 us 11.229 us]

send messages to other actors using Tokio with unbounded channels                                                                             
                        time:   [10.823 us 10.928 us 11.033 us]

create new actors using Crossbeam and Executors with unbounded channels                                                                             
                        time:   [1.1376 us 1.1579 us 1.1786 us]

create new actors using Tokio with unbounded channels                                                                             
                        time:   [2.3946 us 2.5501 us 2.8059 us]
```

In summary, Crossbeam/Executors tends to perform 2.5 to 3 times faster than Tokio so far, and unbounded channels slightly performing bounded ones across both.