### PR TITLE
Introduces a receiver macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ let dispatcher = Arc::new(WorkStealingPoolDispatcher { pool, command_tx });
 let mailbox_fn = Arc::new(unbounded_mailbox_fn());
 ```
 
-Communicating with the actor looks like this:
+Sending a message to an actor looks like this:
 
 ```rust
 let system = ActorContext::<Greet>::new(
@@ -70,6 +70,31 @@ system.actor_ref.tell(SayHello {
     name: "Stage".to_string(),
 });
 ```
+
+We are also able to perform request/reply scenarios using `ask`. For example, using tokio as a runtime:
+
+```rust
+let _ = receiver!(my_actor_ref.ask(
+    &|reply_to| SomeRequest {
+        reply_to: reply_to.to_owned(),
+    },
+    mailbox_fn.to_owned(),
+))
+.recv()
+.await
+.unwrap()
+.downcast_ref::<SomeReply>()
+.unwrap();
+```
+
+There's a `receiver!` macro provided by Stage that, in this case, returns a
+Tokio `Receiver` whereupon a `recv` can then be waited on. The `ask` method of an actor reference
+takes a function that is responsible for producing a request with a `reply_to` actor reference. The
+`reply_to` actor reference to the closure is manufactured by `ask` having called a `mailbox_fn`.
+`mailbox_fn` is a function that produces a Tokio channel.
+
+The result of an `ask` is an `AnyMessage` which must then be downcast to arrive at the type we
+seek.
 
 For complete examples, please consult the tests associated with each dispatcher library.
 

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -70,6 +70,19 @@ pub fn mailbox_fn(
     })
 }
 
+/// A convenience for extracting a Tokio Receiver from a Stage Receiver type.
+/// This can wrap an ActorRef.ask call.
+#[macro_export]
+macro_rules! receiver {
+    ($receiver:expr) => {
+        $receiver
+            .receiver_impl
+            .as_any()
+            .downcast_mut::<TkReceiver<AnyMessage>>()
+            .unwrap()
+    };
+}
+
 struct TkUnboundedReceiverImpl {
     receiver: TkUnboundedReceiver<AnyMessage>,
 }
@@ -122,6 +135,20 @@ pub fn unbounded_mailbox_fn(
         )
     })
 }
+
+/// A convenience for extracting a Tokio Receiver from a Stage Receiver type.
+/// This can wrap an ActorRef.ask call.
+#[macro_export]
+macro_rules! unbounded_receiver {
+    ($receiver:expr) => {
+        $receiver
+            .receiver_impl
+            .as_any()
+            .downcast_mut::<TkUnboundedReceiver<AnyMessage>>()
+            .unwrap()
+    };
+}
+
 struct TaskStopped {
     id: usize,
 }


### PR DESCRIPTION
This macro reduces some boilerplate when calling `ask`.

Fixes #10 