### PR TITLE
Introducing a better ask function

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,27 +74,17 @@ system.actor_ref.tell(SayHello {
 We are also able to perform request/reply scenarios using `ask`. For example, using tokio as a runtime:
 
 ```rust
-let _ = receiver!(my_actor_ref.ask(
-    &|reply_to| SomeRequest {
+actor_ref.ask(
+    &|reply_to| Request {
         reply_to: reply_to.to_owned(),
     },
-    mailbox_fn.to_owned(),
-))
-.recv()
-.await
-.unwrap()
-.downcast_ref::<SomeReply>()
-.unwrap();
+    Duration::from_secs(1),
+)
 ```
 
-There's a `receiver!` macro provided by Stage that, in this case, returns a
-Tokio `Receiver` whereupon a `recv` can then be waited on. The `ask` method of an actor reference
-takes a function that is responsible for producing a request with a `reply_to` actor reference. The
-`reply_to` actor reference to the closure is manufactured by `ask` having called a `mailbox_fn`.
-`mailbox_fn` is a function that produces a Tokio channel.
-
-The result of an `ask` is an `AnyMessage` which must then be downcast to arrive at the type we
-seek.
+The `ask` method of an actor reference takes a function that is responsible for producing a request 
+with a `reply_to` actor reference. Asks always take a timeout parameter which, in the case of Tokio,
+may return an `Elapsed` error.
 
 For complete examples, please consult the tests associated with each dispatcher library.
 

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -17,7 +17,7 @@ executors = "0.8.0"
 stage_core = { path = "../core" }
 stage_dispatch_crossbeam_executors = { path = "../executors" }
 stage_dispatch_tokio = { path = "../tokio" }
-tokio = { version = "1", features = ["rt-multi-thread"] }
+tokio = { version = "1", features = ["rt-multi-thread", "time"] }
 
 [[bench]]
 name = "actors"

--- a/core/src/channel.rs
+++ b/core/src/channel.rs
@@ -26,28 +26,6 @@ pub trait ReceiverImpl {
     fn as_any(&mut self) -> &mut (dyn Any + Send);
 }
 
-/// An error returned from the [`recv_timeout`] method.
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
-pub enum RecvTimeoutError {
-    /// A message could not be received because the channel is empty and the operation timed out.
-    ///
-    /// If this is a zero-capacity channel, then the error indicates that there was no sender
-    /// available to send a message and the operation timed out.
-    Timeout,
-
-    /// The message could not be received because the channel is empty and disconnected.
-    Disconnected,
-}
-
-impl fmt::Display for RecvTimeoutError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            RecvTimeoutError::Timeout => "timed out waiting on receive operation".fmt(f),
-            RecvTimeoutError::Disconnected => "channel is empty and disconnected".fmt(f),
-        }
-    }
-}
-
 /// The sending side of a channel.
 pub struct Sender<T> {
     pub sender_impl: Box<dyn SenderImpl<Item = T> + Send + Sync>,


### PR DESCRIPTION
Ask has been re-implemented and declared in the context of the runtime, as different runtimes have slightly different semantics. The new ask functions are simpler and, in the case of Tokio, faster. Tokio performance now appears to be comparable to Crossbeam/Executors.

Here's what an `ask` now looks like:

```rust
actor_ref.ask(
    &|reply_to| Request {
        reply_to: reply_to.to_owned(),
    },
    Duration::from_secs(1),
)
```
